### PR TITLE
fix: :bug: Fixed API requests and saving selections to Effect settings.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebot-custom-script-vtubestudio",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebot-custom-script-vtubestudio",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "GNU3",
       "dependencies": {
         "@types/ws": "^8.5.6",
@@ -670,6 +670,7 @@
       "resolved": "https://registry.npmjs.org/@crowbartools/firebot-custom-scripts-types/-/firebot-custom-scripts-types-5.63.0.tgz",
       "integrity": "sha512-dh6ejTsFGsIUisOvocRsbeA9NQTW6vpm1ClCqupsBejlb0zIA5/JULpStl1DZsYMa403nU7i6Rw9t6cnXzgzWw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@twurple/api": "^7.0.6",
         "@twurple/auth": "^7.0.6",

--- a/src/firebot/constants.ts
+++ b/src/firebot/constants.ts
@@ -5,4 +5,4 @@ export const BackgroundChangedEvent = "vtube-background-changed";
 export const ModelConfigChangedEvent = "vtube-model-config-changed";
 export const ModelOutlineEvent = "vtube-model-outline";
 export const ModelMovedEvent = "vtube-model-moved";
-export const ModelClickedEvent = "vtube-model-clicked"
+export const ModelClickedEvent = "vtube-model-clicked";

--- a/src/firebot/effects/load-item.ts
+++ b/src/firebot/effects/load-item.ts
@@ -30,6 +30,16 @@ export const loadItemEffect: Firebot.EffectType<{
     description: "Load a new item to the scene",
     icon: "fad fa-box-full",
     categories: ["common"],
+    //@ts-expect-error
+    outputs: [{
+      label: "Loaded Item Instance ID",
+      defaultName: "itemInstanceID",
+      description: "When loading items into the VTube Studio scene, they are given a unique, random ID."
+    }, {
+      label: "Loaded Item Filename",
+      defaultName: "itemFileName",
+      description: "When adding items to the VTube Studio items folder, they are assigned a filename."
+    }]
   },
   /**
   * The HTML template for the Options view (ie options when effect is added to something such as a button.
@@ -59,13 +69,13 @@ export const loadItemEffect: Firebot.EffectType<{
                     <input ng-model="effect.positionY" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
               </div> 
               <div class="input-group" style="margin-top:10px" >
-                    <span class="input-group-addon" id="delay-length-effect-type">Rotation</span>
-                    <input ng-model="effect.rotation" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
-              </div>
-              <div class="input-group" style="margin-top:10px" >
                     <span class="input-group-addon" id="delay-length-effect-type">Size</span>
                     <input ng-model="effect.size" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
               </div> 
+              <div class="input-group" style="margin-top:10px" >
+                    <span class="input-group-addon" id="delay-length-effect-type">Rotation</span>
+                    <input ng-model="effect.rotation" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
+              </div>
               <div class="input-group" style="margin-top:10px" >
                     <span class="input-group-addon" id="delay-length-effect-type">Order</span>
                     <input ng-model="effect.order" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
@@ -164,8 +174,8 @@ export const loadItemEffect: Firebot.EffectType<{
       event.effect.fileName,
       event.effect.positionX,
       event.effect.positionY,
-      event.effect.rotation,
       event.effect.size,
+      event.effect.rotation,
       event.effect.fadeTime,
       event.effect.order,
       event.effect.failIfOrderTaken,

--- a/src/firebot/effects/pin-item.ts
+++ b/src/firebot/effects/pin-item.ts
@@ -84,6 +84,11 @@ export const pinItemEffect: Firebot.EffectType<EffectType> = {
                     <input ng-model="effect.data.pinInfo.size" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">
              </div>
 
+             <div class="input-group" style="margin-top:10px; margin-bottom:10px;" >
+                <span class="input-group-addon" id="delay-length-effect-type">Art Mesh ID</span>
+                <input ng-model="effect.data.pinInfo.artMeshID" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="string">
+            </div>
+
              <div class="input-group" style="margin-top:10px" >
                     <span class="input-group-addon" id="delay-length-effect-type">vertexID1</span>
                     <input ng-model="effect.data.pinInfo.vertexID1" type="text" class="form-control" aria-describedby="delay-length-effect-type" type="text" replace-variables="number">


### PR DESCRIPTION
## Changes
- `package-lock.json`
  - Custom script package from Firebot got updated.
- `load-and-pin-item.ts` (as well as the individual `load-item.ts` and `pin-item.ts`)
  - For the item selector, I removed the instance ID parameter from `selectItem` since there won't be an instance ID until after this effect runs.
  - Changed `getItemList` to select the item based off the filename instead of the instance ID, because there won't be an instance ID until after the effect runs. Additionally, changed the effect validator to check the item's filename instead of the instance ID.
    - Fixed the selected item to save to `$scope.itemSelected`.
  - Changed `getAvailableModels` to select the model based off the ID instead of the name, because models can have the same name.
  - Swapped the rotation and size elements in the UI and API request as they were being passed in the incorrect order before.
  - Added a UI text element to specify the Art Mesh ID the user wants to pin the item to.
- `load-item.ts`
  - Added an `outputs` definition so that the output data is visible to users.

## Testing
Tested locally on my Firebot instance (v5.63.2)